### PR TITLE
Replace `type` with `isinstance`

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -44,7 +44,7 @@ def generate(yaml_path, md_path):
                 for k, v in i.items():
                     if v is None:
                         v = " "
-                    if type(v) is not str:
+                    if not isinstance(v, str):
                         v = str(v)
                     if k == "year":
                         title += f"'{v[-2:]}"


### PR DESCRIPTION
> Object type comparisons should always use isinstance() instead of comparing types directly:

```python
# Correct:
if isinstance(obj, int):
```

```python
# Wrong:
if type(obj) is type(1):
```

https://peps.python.org/pep-0008/#programming-recommendations
https://wemake-python-styleguide.readthedocs.io/en/latest/pages/usage/violations/refactoring.html#wemake_python_styleguide.violations.refactoring.TypeCompareViolation

