### PR TITLE
Set python version for build workflow

### DIFF
--- a/.github/workflows/load-generate.yml
+++ b/.github/workflows/load-generate.yml
@@ -30,6 +30,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12.4"
       - run: pip install -r requirements.txt
       - run: python compile.py cfp.yml README.md
       - uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
ref: #62

In code we use functional available since python `3.11` [datetime.UTC](https://docs.python.org/3/library/datetime.html#datetime.UTC)