### PR TITLE
Change rultor image

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -3,7 +3,7 @@
 ---
 # yamllint disable rule:line-length
 docker:
-  image: yegor256/python
+  image: python:3.13.2-bookworm
 merge:
   script: |
     pip3 install -r requirements.txt


### PR DESCRIPTION
Now rultor fails with:

```
    from typing import Literal, TypeAlias, TypedDict
E   ImportError: cannot import name 'TypeAlias' from 'typing'
```

because it use `python3.9`. This PR up python version to latest

Failed PR's:

#193
#194
#195
#196