### PR TITLE
Update SEAA 2026 CFP deadline to April 29

### DIFF
--- a/cfp.yml
+++ b/cfp.yml
@@ -459,7 +459,7 @@ SEAA:
   short: 4
   full: 8
   format: 2C
-  cfp: '2026-04-15'
+  cfp: '2026-04-29'
   country: PL
   later: false
 
@@ -518,3 +518,4 @@ SSBSE:
   cfp: '2026-03-24'
   country: CA
   later: true
+


### PR DESCRIPTION
The SEAA 2026 (52nd Euromicro Conference on Software Engineering and Advanced Applications) extended its paper submission deadline from April 15 to **April 29, 2026** (firm).

The original deadline was April 15, 2026, but the conference officially extended it. This is confirmed by:
- WikiCFP listing: https://www.wikicfp.com/cfp/servlet/event.showcfp?eventid=191218
- Conference website: https://dsd-seaa.com/seaa2026/

This PR updates the `cfp` field for SEAA from `2026-04-15` to `2026-04-29`.

@yegor256 please review.