### PR TITLE
Update CGO, ESOP, FSE, ICSA to 2027 editions

### DIFF
--- a/cfp.yml
+++ b/cfp.yml
@@ -58,8 +58,8 @@ CC:
   later: false
 
 CGO:
-  year: 2026
-  url: https://2026.cgo.org
+  year: 2027
+  url: https://conf.researchr.org/home/cgo-2027
   publisher: ACM
   rank: A
   core: https://portal.core.edu.au/conf-ranks/1362
@@ -68,7 +68,7 @@ CGO:
   full: 11
   format: 2C
   cfp: closed
-  country: AU
+  country: US
   later: false
 
 CLEI:
@@ -128,8 +128,8 @@ ECSA:
   later: false
 
 ESOP:
-  year: 2026
-  url: https://etaps.org/2026/conferences/esop/
+  year: 2027
+  url: https://etaps.org/2027/conferences/esop/
   publisher: Springer
   rank: A
   core: https://portal.core.edu.au/conf-ranks/514
@@ -137,13 +137,13 @@ ESOP:
   short: 15
   full: 25
   format: LNCS
-  cfp: closed
-  country: CZ
+  cfp: '2026-05-28'
+  country: DK
   later: false
 
 FSE:
-  year: 2026
-  url: https://conf.researchr.org/home/fse-2026
+  year: 2027
+  url: https://conf.researchr.org/home/fse-2027
   publisher: ACM
   rank: A*
   core: https://portal.core.edu.au/conf-ranks/52
@@ -152,7 +152,7 @@ FSE:
   full: 18
   format: 1C
   cfp: closed
-  country: CA
+  country: CN
   later: false
 
 ICFEM:
@@ -212,8 +212,8 @@ ICPC:
   later: false
 
 ICSA:
-  year: 2026
-  url: https://conf.researchr.org/home/icsa-2026
+  year: 2027
+  url: https://conf.researchr.org/home/icsa-2027
   publisher: IEEE
   rank: A
   core: https://portal.core.edu.au/conf-ranks/791
@@ -222,7 +222,7 @@ ICSA:
   full: 10
   format: null
   cfp: closed
-  country: NL
+  country: AU
   later: false
 
 ICSE:

--- a/cfp.yml
+++ b/cfp.yml
@@ -129,7 +129,7 @@ ECSA:
 
 ESOP:
   year: 2027
-  url: https://etaps.org/2027/conferences/esop/
+  url: https://etaps.org/2027/
   publisher: Springer
   rank: A
   core: https://portal.core.edu.au/conf-ranks/514


### PR DESCRIPTION
## Summary

Updated 4 conferences to their next upcoming editions with current CFP information:

- **ESOP 2027**: Copenhagen, Denmark (DK) — CFP deadline **2026-05-28** (ETAPS 2027 Round 1, currently open)
- **CGO 2027**: Salt Lake City, USA (US) — CFP not yet announced
- **FSE 2027**: Shenzhen, China (CN) — CFP not yet announced
- **ICSA 2027**: Sydney, Australia (AU) — CFP not yet announced

## Sources

- ESOP/ETAPS 2027: https://etaps.org/2027/ (April 10–15, 2027, Copenhagen; submission deadline May 28, 2026)
- CGO 2027: https://conf.researchr.org/home/cgo-2027 (Salt Lake City, USA)
- FSE 2027: https://conf.researchr.org/home/fse-2027 (July 12–16, 2027, Shenzhen, China)
- ICSA 2027: https://conf.researchr.org/home/icsa-2027 (March 8–12, 2027, Sydney, Australia)