### PR TITLE
Update ESOP and PPDP CFP dates

### DIFF
--- a/cfp.yml
+++ b/cfp.yml
@@ -137,7 +137,7 @@ ESOP:
   short: 15
   full: 25
   format: LNCS
-  cfp: '2026-05-28'
+  cfp: '2026-10-15'
   country: DK
   later: false
 
@@ -366,8 +366,8 @@ POPL:
   later: false
 
 PPDP:
-  year: 2026
-  url: https://icfp26.sigplan.org/home/lopstr-ppdp-2026
+  year: 2027
+  url: https://icfp27.sigplan.org/home/lopstr-ppdp-2027
   publisher: ACM
   rank: C
   core: https://portal.core.edu.au/conf-ranks/1176
@@ -375,9 +375,9 @@ PPDP:
   short: 5
   full: 12
   format: 2C
-  cfp: '2026-05-27'
+  cfp: closed
   country: US
-  later: false
+  later: true
 
 PPoPP:
   year: 2027


### PR DESCRIPTION
## Summary

- **ESOP 2027**: Updated CFP deadline from `2026-05-28` (Round 1, now expired) to `2026-10-15` (Round 2 deadline). ESOP 2027 uses a two-round submission system — Round 1 closed May 28, but Round 2 is still open until October 15, 2026. Source: https://etaps.org/2027/conferences/esop/
- **PPDP 2026**: CFP deadline (`2026-05-27`) has passed. Updated to year 2027 with `cfp: closed` and `later: true` since PPDP 2027 has not been announced yet. URL updated to follow the ICFP co-location naming pattern (`icfp27.sigplan.org/home/lopstr-ppdp-2027`).

## Test plan

- [ ] All existing tests pass (`pytest -m 'not content'`)
- [ ] YAML is valid
- [ ] ESOP 2027 Round 2 deadline verified on the official ETAPS website
- [ ] PPDP 2027 not yet announced; marked as `closed`/`later: true` accordingly

https://claude.ai/code/session_01SHZibiKepC9PH8Lay45pM6