### PR TITLE
Update CFP dates and fix conference metadata

### DIFF
--- a/cfp.yml
+++ b/cfp.yml
@@ -11,7 +11,7 @@ APLAS:
   short: null
   full: 17
   format: LNCS
-  cfp: '2026-06-08'
+  cfp: '2026-06-15'
   country: IN
   later: false
 
@@ -54,7 +54,7 @@ CC:
   full: 10
   format: 2C
   cfp: closed
-  country: AU
+  country: US
   later: true
 
 CGO:
@@ -165,7 +165,7 @@ ICFEM:
   short: null
   full: 16
   format: LNCS
-  cfp: '2026-06-08'
+  cfp: '2026-06-22'
   country: UK
   later: false
 
@@ -292,7 +292,7 @@ ICST:
   full: 10
   format: 2C
   cfp: closed
-  country: KR
+  country: ES
   later: true
 
 ISSRE:
@@ -389,9 +389,9 @@ PPoPP:
   short: null
   full: 10
   format: null
-  cfp: closed
-  country: AU
-  later: true
+  cfp: '2026-08-03'
+  country: US
+  later: false
 
 QRS:
   year: 2027
@@ -422,8 +422,8 @@ REFSQ:
   later: false
 
 SANER:
-  year: 2028
-  url: https://conf.researchr.org/home/saner-2028
+  year: 2027
+  url: https://conf.researchr.org/home/saner-2027
   publisher: IEEE
   rank: A
   core: https://portal.core.edu.au/conf-ranks/2280
@@ -431,9 +431,9 @@ SANER:
   short: null
   full: 12
   format: null
-  cfp: closed
+  cfp: '2026-09-25'
   country: US
-  later: true
+  later: false
 
 SCAM:
   year: 2026
@@ -502,7 +502,7 @@ SPLASH:
   full: null
   format: null
   cfp: '2026-06-26'
-  country: SG
+  country: US
   later: false
 
 SSBSE:


### PR DESCRIPTION
## Summary

- **APLAS 2026**: Updated CFP deadline from 2026-06-08 to 2026-06-15 (actual deadline on conference website)
- **ICFEM 2026**: Updated CFP deadline from 2026-06-08 to 2026-06-22 (extended deadline on conference website)
- **PPoPP 2027**: CFP is now open — updated from `closed` to `2026-08-03`; fixed country from AU to US (Salt Lake City, Utah)
- **SANER**: Corrected year from 2028 to 2027, updated URL to saner-2027, CFP deadline `2026-09-25`
- **CC 2027**: Fixed country from AU to US (Salt Lake City, co-located with CGO/PPoPP/HPCA 2027)
- **ICST 2027**: Fixed country from KR to ES (San Sebastian, Spain — ICST 2026 was in Korea, not 2027)
- **SPLASH 2026**: Fixed country from SG to US (Oakland, California)

## Sources

- APLAS 2026: https://conf.researchr.org/home/aplas-atva-2026 — "Mon 15 Jun 2026 APLAS submission deadline"
- ICFEM 2026: https://icfem2026.github.io/ — "June 8 → June 22, 2026" (extended)
- PPoPP 2027: https://conf.researchr.org/home/PPoPP-2027 — "Mon 3 Aug 2026 Main Conference paper submission"
- SANER 2027: https://conf.researchr.org/home/saner-2027 — "Fri 25 Sep 2026 Research Track Paper submission" (Richmond, Virginia)
- CC 2027: co-located with CGO/PPoPP/HPCA 2027 in Salt Lake City
- ICST 2027: https://conf.researchr.org/home/icst-2027 — "San Sebastian, Spain, May 17-21, 2027"
- SPLASH 2026: https://2026.splashcon.org/dates — "Oakland, California"

https://claude.ai/code/session_01Tqnzr8sJECcGveoagSGUmu