### PR TITLE
Fix APLAS 2026: correct CFP deadline and country

### DIFF
--- a/cfp.yml
+++ b/cfp.yml
@@ -11,8 +11,8 @@ APLAS:
   short: null
   full: 17
   format: LNCS
-  cfp: closed
-  country: IN
+  cfp: '2026-06-22'
+  country: HK
   later: false
 
 ASE:


### PR DESCRIPTION
## Summary

- Changed APLAS 2026 `cfp` from `closed` to `'2026-06-22'`: the paper submission deadline is June 22, 2026 (verified at https://conf.researchr.org/home/aplas-atva-2026)
- Changed `country` from `IN` (India) to `HK` (Hong Kong): APLAS & ATVA 2026 is held at HKUST in Hong Kong SAR China

## Test plan

- [x] All local tests pass (`pytest -m 'not content'`)
- [x] All tests pass (`pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uAoZMVJdq2PcRqJh6orxS