### PR TITLE
Refresh outdated CFP deadlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ please send us a pull request.
 | [ASE'27](<https://conf.researchr.org/home/ase-2027>) | ACM | [A*](<https://conf.researchr.org/home/ase-2027>) | SE | | 10 | | closed | DE |
 | [ASPLOS'27](<https://www.asplos-conference.org/asplos2027/cfp/>) | ACM | [A*](<https://portal.core.edu.au/conf-ranks/147>) | SE | | 11 | 2C | 26-Sep | GR |
 | [FSE'27](<https://conf.researchr.org/home/fse-2027>) | ACM | [A*](<https://portal.core.edu.au/conf-ranks/52>) | SE | | 18 | 1C | 26-Oct | CN |
-| [ICSE'27](<https://conf.researchr.org/home/icse-2027>) | ACM | [A*](<https://portal.core.edu.au/conf-ranks/1209>) | SE | | 10 | | 26-Jun | IE |
+| [ICSE'27](<https://conf.researchr.org/home/icse-2027>) | ACM | [A*](<https://portal.core.edu.au/conf-ranks/1209>) | SE | | 10 | | closed | IE |
 | [ICSE-NIER'27](<https://conf.researchr.org/track/icse-2027/icse-2027-new-ideas-and-emerging-results--nier->) | ACM | [A*](<https://portal.core.edu.au/conf-ranks/1209>) | SE | 4 | | | 26-Oct | IE |
 | [ICSE-SRC'27](<https://conf.researchr.org/track/icse-2027/icse-2027-src>) | ACM | [A*](<https://portal.core.edu.au/conf-ranks/1209>) | SE | 2 | | | 26-Nov | IE |
 | [PLDI'27](<https://pldi27.sigplan.org>) | ACM | [A*](<https://pldi27.sigplan.org>) | PL | | 20 | 1C | closed | US |
-| [POPL'27](<https://conf.researchr.org/home/POPL-2027>) | ACM | [A*](<https://portal.core.edu.au/conf-ranks/82>) | SE | | 25 | | 26-Jul | MX |
+| [POPL'27](<https://conf.researchr.org/home/POPL-2027>) | ACM | [A*](<https://portal.core.edu.au/conf-ranks/82>) | SE | | 25 | | closed | MX |
 | [CGO'27](<https://conf.researchr.org/home/cgo-2027>) | ACM | [A](<https://portal.core.edu.au/conf-ranks/1362>) | PL | | 11 | 2C | 26-Sep | US |
 | [EASE'27](<https://conf.researchr.org/home/ease-2027>) | ACM | [A](<https://conf.researchr.org/home/ease-2027>) | SE | | 10 | | closed | UK |
-| [ECOOP'27](<https://2027.ecoop.org>) | ACM | [A](<https://2027.ecoop.org>) | SE | 12 | 25 | | closed | BE |
+| [ECOOP'27](<https://2027.ecoop.org>) | ACM | [A](<https://portal.core.edu.au/conf-ranks/488>) | SE | 12 | 25 | | 26-Nov | IT |
 | [ECSA'27](<https://conf.researchr.org/home/ecsa-2027>) | Springer | [A](<https://conf.researchr.org/home/ecsa-2027>) | SA | 8 | 16 | LNCS | closed | IT |
 | [ESOP'27](<https://etaps.org/2027/conferences/esop/>) | Springer | [A](<https://portal.core.edu.au/conf-ranks/514>) | PL | 15 | 25 | LNCS | 26-Oct | DK |
 | [ICFP'27](<https://icfp27.sigplan.org>) | ACM | [A](<https://icfp27.sigplan.org>) | PL | 12 | 25 | 1C | closed | US |
@@ -37,14 +37,14 @@ please send us a pull request.
 | [ICPC'27](<https://conf.researchr.org/home/icpc-2027>) | ACM | [A](<https://conf.researchr.org/home/icpc-2027>) | SE | | 10 | | closed | CA |
 | [ICSA'27](<https://conf.researchr.org/home/icsa-2027>) | IEEE | [A](<https://portal.core.edu.au/conf-ranks/791>) | SE, SA | 8 | 10 | | 26-Nov | AU |
 | [ICSME'27](<https://conf.researchr.org/home/icsme-2027>) | IEEE | [A](<https://conf.researchr.org/home/icsme-2027>) | SE | | 10 | | closed | IT |
-| [ICST'27](<https://conf.researchr.org/home/icst-2027>) | IEEE | [A](<https://conf.researchr.org/home/icst-2027>) | ST | | 10 | 2C | closed | ES |
+| [ICST'27](<https://conf.researchr.org/home/icst-2027>) | IEEE | [A](<https://portal.core.edu.au/conf-ranks/1221>) | ST | | 10 | 2C | 26-Nov | ES |
 | [ISSRE'27](<https://conf.researchr.org/home/issre-2027>) | IEEE | [A](<https://conf.researchr.org/home/issre-2027>) | SE | 10 | 12 | 2C | closed | CY |
-| [ISSTA'26](<https://conf.researchr.org/home/issta-2026>) | ACM | [A](<https://portal.core.edu.au/conf-ranks/1412>) | ST | | 18 | 1C | 26-Jun | US |
-| [MSR'27](<https://2027.msrconf.org>) | IEEE | [A](<https://2027.msrconf.org>) | SE | 4 | 10 | | closed | IE |
+| [ISSTA'26](<https://conf.researchr.org/home/issta-2026>) | ACM | [A](<https://portal.core.edu.au/conf-ranks/1412>) | ST | | 18 | 1C | closed | US |
+| [MSR'27](<https://2027.msrconf.org>) | IEEE | [A](<https://portal.core.edu.au/conf-ranks/711>) | SE | 4 | 10 | | 26-Oct | IE |
 | [SANER'27](<https://conf.researchr.org/home/saner-2027>) | IEEE | [A](<https://portal.core.edu.au/conf-ranks/2280>) | SE | | 12 | | 26-Sep | US |
-| [SEAMS'27](<https://conf.researchr.org/home/seams-2027>) | IEEE | [A](<https://conf.researchr.org/home/seams-2027>) | SE | 6 | 10 | | closed | IE |
-| [SPLASH'26](<https://2026.splashcon.org>) | ACM | [A](<https://portal.core.edu.au/conf-ranks/18>) | PL | | | | 26-Jun | US |
-| [APLAS'26](<https://conf.researchr.org/home/aplas-atva-2026>) | Springer | [B](<https://portal.core.edu.au/conf-ranks/171>) | PL | | 17 | LNCS | closed | IN |
+| [SEAMS'27](<https://conf.researchr.org/home/seams-2027>) | IEEE | [A](<https://portal.core.edu.au/conf-ranks/2281>) | SE | 6 | 10 | | 26-Oct | IE |
+| [SPLASH'26](<https://2026.splashcon.org>) | ACM | [A](<https://portal.core.edu.au/conf-ranks/18>) | PL | | | | closed | US |
+| [APLAS'26](<https://conf.researchr.org/home/aplas-atva-2026>) | Springer | [B](<https://portal.core.edu.au/conf-ranks/171>) | PL | | 17 | LNCS | closed | HK |
 | [CC'27](<https://conf.researchr.org/home/CC-2027>) | ACM | [B](<https://conf.researchr.org/home/CC-2027>) | PL | | 10 | 2C | closed | US |
 | [PPoPP'27](<https://conf.researchr.org/home/ppopp-2027>) | ACM | [B](<https://portal.core.edu.au/conf-ranks/1691>) | PL | | 10 | | 26-Aug | US |
 | [REFSQ'27](<https://2027.refsq.org>) | Springer | [B](<https://portal.core.edu.au/conf-ranks/1521>) | SE | 8 | 15 | LNCS | 26-Nov | CH |
@@ -52,7 +52,7 @@ please send us a pull request.
 | [SLE'27](<http://www.sleconf.org/2027>) | ACM | [B](<http://www.sleconf.org/2027>) | SE, PL | 6 | 12 | 2C | closed | FR |
 | [SSBSE'27](<https://conf.researchr.org/home/ssbse-2027>) | Springer | [B](<https://conf.researchr.org/home/ssbse-2027>) | SE | 6 | 15 | LNCS | closed | CA |
 | [CLEI'27](<https://conferencia2027.clei.org>) | IEEE | [C](<https://conferencia2027.clei.org>) | SE | 4 | 10 | | closed | MX |
-| [ICFEM'26](<https://icfem2026.github.io/>) | Springer | [C](<https://portal.core.edu.au/conf-ranks/1031>) | SE | | 16 | LNCS | 26-Jun | UK |
+| [ICFEM'26](<https://icfem2026.github.io/>) | Springer | [C](<https://portal.core.edu.au/conf-ranks/1031>) | SE | | 16 | LNCS | closed | UK |
 | [PPDP'27](<https://icfp27.sigplan.org/home/lopstr-ppdp-2027>) | ACM | [C](<https://icfp27.sigplan.org/home/lopstr-ppdp-2027>) | PL | 5 | 12 | 2C | closed | US |
 | [QRS'27](<https://qrs27.techconf.org>) | IEEE | [C](<https://qrs27.techconf.org>) | SE | 10 | 12 | 2C | closed | IT |
 | [SCAM'26](<https://conf.researchr.org/home/scam-2026>) | IEEE | [C](<https://portal.core.edu.au/conf-ranks/718>) | SE | | 12 | 2C | closed | IT |

--- a/cfp.yml
+++ b/cfp.yml
@@ -11,7 +11,7 @@ APLAS:
   short: null
   full: 17
   format: LNCS
-  cfp: '2026-06-22'
+  cfp: closed
   country: HK
   later: false
 
@@ -109,9 +109,9 @@ ECOOP:
   short: 12
   full: 25
   format: null
-  cfp: closed
-  country: BE
-  later: true
+  cfp: '2026-11-19'
+  country: IT
+  later: false
 
 ECSA:
   year: 2027
@@ -165,7 +165,7 @@ ICFEM:
   short: null
   full: 16
   format: LNCS
-  cfp: '2026-06-22'
+  cfp: closed
   country: UK
   later: false
 
@@ -235,7 +235,7 @@ ICSE:
   short: null
   full: 10
   format: null
-  cfp: '2026-06-30'
+  cfp: closed
   country: IE
   later: false
 
@@ -291,9 +291,9 @@ ICST:
   short: null
   full: 10
   format: 2C
-  cfp: closed
+  cfp: '2026-11-02'
   country: ES
-  later: true
+  later: false
 
 ISSRE:
   year: 2027
@@ -319,7 +319,7 @@ ISSTA:
   short: null
   full: 18
   format: 1C
-  cfp: '2026-06-25'
+  cfp: closed
   country: US
   later: false
 
@@ -333,9 +333,9 @@ MSR:
   short: 4
   full: 10
   format: null
-  cfp: closed
+  cfp: '2026-10-23'
   country: IE
-  later: true
+  later: false
 
 PLDI:
   year: 2027
@@ -361,7 +361,7 @@ POPL:
   short: null
   full: 25
   format: null
-  cfp: '2026-07-09'
+  cfp: closed
   country: MX
   later: false
 
@@ -473,9 +473,9 @@ SEAMS:
   short: 6
   full: 10
   format: null
-  cfp: closed
+  cfp: '2026-10-21'
   country: IE
-  later: true
+  later: false
 
 SLE:
   year: 2027
@@ -501,7 +501,7 @@ SPLASH:
   short: null
   full: null
   format: null
-  cfp: '2026-06-26'
+  cfp: closed
   country: US
   later: false
 


### PR DESCRIPTION
## Summary

Several entries in `cfp.yml` had a submission deadline that already passed (relative to 2026-07-15) or were marked `closed` with no future deadline tracked. I researched each conference's official website to find the real, currently-published submission deadline for the next edition where paper submission is still possible, and updated the entries accordingly:

- **ECOOP'27** (Turin, Italy) — Round 1 deadline `2026-11-19`, corrected country `BE` → `IT`
- **ICST'27** (San Sebastián, Spain) — Research Papers deadline `2026-11-02`
- **MSR'27** (Dublin, Ireland) — full paper deadline `2026-10-23`
- **SEAMS'27** (Dublin, Ireland) — Research Track deadline `2026-10-21`

For these, `later: true` was flipped to `later: false` since the sites are now live and confirmed, matching the existing convention in the file.

The following had a passed deadline with no future edition announced yet (no live site/CFP for a later edition could be found), so they're marked `cfp: closed` for now:

- **APLAS'26**, **ICFEM'26**, **ICSE'27**, **ISSTA'26**, **POPL'27**, **SPLASH'26**

All other `closed` entries were checked but had no confirmed future CFP to report yet, so they were left unchanged.

`README.md` was regenerated via `python compile.py cfp.yml README.md`.

## Test plan

- [x] `pytest -m 'not content'` — 12 passed, 100% coverage
- [x] `pytest -m 'content' --cov-fail-under=0` — 43 passed (includes live HTTP validation of every non-`later` URL/core link, including the four newly-flipped entries)
- [x] `yamllint -c .yamllint.yml cfp.yml`
- [x] `markdownlint-cli2 --config .markdownlint-cli2.jsonc README.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_01WP6wHAXUhxfYpbdcB1wn6Q)_