### PR TITLE
Refresh CFP deadlines for 12 conferences

### DIFF
--- a/cfp.yml
+++ b/cfp.yml
@@ -11,7 +11,7 @@ APLAS:
   short: null
   full: 17
   format: LNCS
-  cfp: '2026-06-22'
+  cfp: closed
   country: HK
   later: false
 
@@ -96,7 +96,7 @@ EASE:
   full: 10
   format: null
   cfp: closed
-  country: UK
+  country: VN
   later: true
 
 ECOOP:
@@ -109,9 +109,9 @@ ECOOP:
   short: 12
   full: 25
   format: null
-  cfp: closed
-  country: BE
-  later: true
+  cfp: '2026-11-19'
+  country: IT
+  later: false
 
 ECSA:
   year: 2027
@@ -165,7 +165,7 @@ ICFEM:
   short: null
   full: 16
   format: LNCS
-  cfp: '2026-06-22'
+  cfp: closed
   country: UK
   later: false
 
@@ -207,9 +207,9 @@ ICPC:
   short: null
   full: 10
   format: null
-  cfp: closed
-  country: CA
-  later: true
+  cfp: '2026-11-05'
+  country: IE
+  later: false
 
 ICSA:
   year: 2027
@@ -235,7 +235,7 @@ ICSE:
   short: null
   full: 10
   format: null
-  cfp: '2026-06-30'
+  cfp: closed
   country: IE
   later: false
 
@@ -291,9 +291,9 @@ ICST:
   short: null
   full: 10
   format: 2C
-  cfp: closed
+  cfp: '2026-11-02'
   country: ES
-  later: true
+  later: false
 
 ISSRE:
   year: 2027
@@ -319,7 +319,7 @@ ISSTA:
   short: null
   full: 18
   format: 1C
-  cfp: '2026-06-25'
+  cfp: closed
   country: US
   later: false
 
@@ -333,9 +333,9 @@ MSR:
   short: 4
   full: 10
   format: null
-  cfp: closed
+  cfp: '2026-10-23'
   country: IE
-  later: true
+  later: false
 
 PLDI:
   year: 2027
@@ -361,7 +361,7 @@ POPL:
   short: null
   full: 25
   format: null
-  cfp: '2026-07-09'
+  cfp: closed
   country: MX
   later: false
 
@@ -473,9 +473,9 @@ SEAMS:
   short: 6
   full: 10
   format: null
-  cfp: closed
+  cfp: '2026-10-21'
   country: IE
-  later: true
+  later: false
 
 SLE:
   year: 2027
@@ -501,7 +501,7 @@ SPLASH:
   short: null
   full: null
   format: null
-  cfp: '2026-06-26'
+  cfp: closed
   country: US
   later: false
 


### PR DESCRIPTION
## Summary

Went through every entry in `cfp.yml` whose `cfp` date was in the past or `closed`, checked each conference's official website for its actual upcoming paper-submission deadline, and updated the ones where new information is available.

- **ECOOP'27**: `closed` → `2026-11-19` (round 1 deadline; host corrected `BE` → `IT`, Turin)
- **ICPC'27**: `closed` → `2026-11-05` (host corrected `CA` → `IE`, Dublin, co-located with ICSE 2027)
- **ICST'27**: `closed` → `2026-11-02`
- **MSR'27**: `closed` → `2026-10-23`
- **SEAMS'27**: `closed` → `2026-10-21`
- **EASE'27**: host corrected `UK` → `VN` (moved to Hanoi; CFP still not announced)
- **APLAS'26, ICFEM'26, ISSTA'26, POPL'27, ICSE'27, SPLASH'26**: expired dates marked `closed` — their main research-track deadlines have passed and no next round/edition is currently published

For conferences whose deadline moved from `closed` to a real date, I also flipped `later: true` → `false` so the daily link-check job validates the new (now-live) CFP URL, matching the convention used elsewhere in the file.

The remaining conferences that were already `closed` (ASE, CC, CLEI, ECSA, ICFP, ICFP-SPLASH, ICSME, ISSRE, PLDI, PPDP, QRS, SCAM, SEAA, SLE, SSBSE) were individually re-checked against their official sites; none have an announced future submission deadline yet, so they were left unchanged.

## Test plan

- [x] `python3 -m pytest -m 'not content'` — 12 passed
- [x] `yamllint -c .yamllint.yml cfp.yml` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('cfp.yml'))"` — parses, 37 entries

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01A8a6AFPRdM3CLATpWobdww

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8a6AFPRdM3CLATpWobdww)_