### PR TITLE
Refresh stale and closed CFP entries

### DIFF
--- a/cfp.yml
+++ b/cfp.yml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 ---
 APLAS:
-  year: 2026
-  url: https://conf.researchr.org/home/aplas-atva-2026
+  year: 2027
+  url: https://conf.researchr.org/home/aplas-atva-2027
   publisher: Springer
   rank: B
   core: https://portal.core.edu.au/conf-ranks/171
@@ -11,9 +11,9 @@ APLAS:
   short: null
   full: 17
   format: LNCS
-  cfp: '2026-06-22'
+  cfp: closed
   country: HK
-  later: false
+  later: true
 
 ASE:
   year: 2027
@@ -45,7 +45,7 @@ ASPLOS:
 
 CC:
   year: 2027
-  url: https://conf.researchr.org/home/CC-2027
+  url: https://conf.researchr.org/home/hpca-cgo-ppopp-cc-2027
   publisher: ACM
   rank: B
   core: https://portal.core.edu.au/conf-ranks/936
@@ -96,7 +96,7 @@ EASE:
   full: 10
   format: null
   cfp: closed
-  country: UK
+  country: VN
   later: true
 
 ECOOP:
@@ -109,9 +109,9 @@ ECOOP:
   short: 12
   full: 25
   format: null
-  cfp: closed
-  country: BE
-  later: true
+  cfp: '2026-11-19'
+  country: IT
+  later: false
 
 ECSA:
   year: 2027
@@ -156,8 +156,8 @@ FSE:
   later: false
 
 ICFEM:
-  year: 2026
-  url: https://icfem2026.github.io/
+  year: 2027
+  url: https://icfem2027.github.io/
   publisher: Springer
   rank: C
   core: https://portal.core.edu.au/conf-ranks/1031
@@ -165,9 +165,9 @@ ICFEM:
   short: null
   full: 16
   format: LNCS
-  cfp: '2026-06-22'
+  cfp: closed
   country: UK
-  later: false
+  later: true
 
 ICFP:
   year: 2027
@@ -207,9 +207,9 @@ ICPC:
   short: null
   full: 10
   format: null
-  cfp: closed
-  country: CA
-  later: true
+  cfp: '2026-11-05'
+  country: IE
+  later: false
 
 ICSA:
   year: 2027
@@ -235,9 +235,9 @@ ICSE:
   short: null
   full: 10
   format: null
-  cfp: '2026-06-30'
+  cfp: closed
   country: IE
-  later: false
+  later: true
 
 ICSE-NIER:
   year: 2027
@@ -291,9 +291,9 @@ ICST:
   short: null
   full: 10
   format: 2C
-  cfp: closed
+  cfp: '2026-11-02'
   country: ES
-  later: true
+  later: false
 
 ISSRE:
   year: 2027
@@ -310,8 +310,8 @@ ISSRE:
   later: true
 
 ISSTA:
-  year: 2026
-  url: https://conf.researchr.org/home/issta-2026
+  year: 2027
+  url: https://conf.researchr.org/home/issta-2027
   publisher: ACM
   rank: A
   core: https://portal.core.edu.au/conf-ranks/1412
@@ -319,9 +319,9 @@ ISSTA:
   short: null
   full: 18
   format: 1C
-  cfp: '2026-06-25'
+  cfp: closed
   country: US
-  later: false
+  later: true
 
 MSR:
   year: 2027
@@ -333,9 +333,9 @@ MSR:
   short: 4
   full: 10
   format: null
-  cfp: closed
+  cfp: '2026-10-23'
   country: IE
-  later: true
+  later: false
 
 PLDI:
   year: 2027
@@ -361,9 +361,9 @@ POPL:
   short: null
   full: 25
   format: null
-  cfp: '2026-07-09'
+  cfp: closed
   country: MX
-  later: false
+  later: true
 
 PPDP:
   year: 2027
@@ -436,8 +436,8 @@ SANER:
   later: false
 
 SCAM:
-  year: 2026
-  url: https://conf.researchr.org/home/scam-2026
+  year: 2027
+  url: https://conf.researchr.org/home/scam-2027
   publisher: IEEE
   rank: C
   core: https://portal.core.edu.au/conf-ranks/718
@@ -447,7 +447,7 @@ SCAM:
   format: 2C
   cfp: closed
   country: IT
-  later: false
+  later: true
 
 SEAA:
   year: 2027
@@ -473,9 +473,9 @@ SEAMS:
   short: 6
   full: 10
   format: null
-  cfp: closed
+  cfp: '2026-10-21'
   country: IE
-  later: true
+  later: false
 
 SLE:
   year: 2027
@@ -492,8 +492,8 @@ SLE:
   later: true
 
 SPLASH:
-  year: 2026
-  url: https://2026.splashcon.org
+  year: 2027
+  url: https://2027.splashcon.org
   publisher: ACM
   rank: A
   core: https://portal.core.edu.au/conf-ranks/18
@@ -501,9 +501,9 @@ SPLASH:
   short: null
   full: null
   format: null
-  cfp: '2026-06-26'
+  cfp: closed
   country: US
-  later: false
+  later: true
 
 SSBSE:
   year: 2027


### PR DESCRIPTION
## Summary

Went through `cfp.yml` and found 27 entries with either a past-due `cfp` date or `cfp: closed` (some left over from earlier stale-data sweeps, e.g. #339, #353, #357). Researched each conference's official site (conf.researchr.org, SIGPLAN, dedicated conference sites, DBLP) for a real, confirmed, future submission deadline.

**Real upcoming CFP deadlines found and updated:**
- ECOOP 2027: `2026-11-19` (also fixed country BE → IT, Turin)
- ICPC 2027: `2026-11-05` (also fixed country CA → IE, Dublin)
- ICST 2027: `2026-11-02`
- MSR 2027: `2026-10-23`
- SEAMS 2027: `2026-10-21`

**No next-edition CFP announced yet — advanced to a `closed`/`later: true` placeholder for the next edition** (previously pointed at an edition whose deadline had already passed with no future round): APLAS, ICFEM, ISSTA, SPLASH, ICSE, POPL, SCAM.

**Other metadata fixes found along the way:**
- EASE: country UK → VN (2027 edition confirmed for Hanoi, Vietnam)
- CC: URL updated — CC 2027 appears merged into the joint `hpca-cgo-ppopp-cc-2027` conference page

**Left unchanged** (still genuinely no future CFP announced, verified live): ASE, CLEI, ECSA, ICFP, ICFP-SPLASH, ICSME, ISSRE, PLDI, PPDP, QRS, SEAA, SLE, SSBSE. PPoPP's `cfp: 2026-08-03` was re-verified directly against the official site and is accurate (not stale), so left as-is.

All URLs and `core` rank links for entries newly flipped to `later: false` were verified reachable (HTTP 200).

## Test plan

- [x] `pytest -m 'not content'` passes
- [x] `pytest -m 'content' --cov-fail-under=0` passes (includes live URL/core link validation for all `later: false` entries)
- [x] `yamllint -c .yamllint.yml cfp.yml` passes

https://claude.ai/code/session_01TainX7ZkvxvvAMC8mekbVH


---
_Generated by [Claude Code](https://claude.ai/code/session_01TainX7ZkvxvvAMC8mekbVH)_