### PR TITLE
Update CFP dates for conferences with expired/unknown deadlines

### DIFF
--- a/cfp.yml
+++ b/cfp.yml
@@ -11,7 +11,7 @@ APLAS:
   short: null
   full: 17
   format: LNCS
-  cfp: '2026-06-22'
+  cfp: closed
   country: HK
   later: false
 
@@ -109,8 +109,8 @@ ECOOP:
   short: 12
   full: 25
   format: null
-  cfp: closed
-  country: BE
+  cfp: '2026-11-19'
+  country: IT
   later: true
 
 ECSA:
@@ -165,7 +165,7 @@ ICFEM:
   short: null
   full: 16
   format: LNCS
-  cfp: '2026-06-22'
+  cfp: closed
   country: UK
   later: false
 
@@ -207,8 +207,8 @@ ICPC:
   short: null
   full: 10
   format: null
-  cfp: closed
-  country: CA
+  cfp: '2026-11-05'
+  country: IE
   later: true
 
 ICSA:
@@ -235,7 +235,7 @@ ICSE:
   short: null
   full: 10
   format: null
-  cfp: '2026-06-30'
+  cfp: closed
   country: IE
   later: false
 
@@ -291,7 +291,7 @@ ICST:
   short: null
   full: 10
   format: 2C
-  cfp: closed
+  cfp: '2026-11-02'
   country: ES
   later: true
 
@@ -310,8 +310,8 @@ ISSRE:
   later: true
 
 ISSTA:
-  year: 2026
-  url: https://conf.researchr.org/home/issta-2026
+  year: 2027
+  url: https://conf.researchr.org/home/issta-2027
   publisher: ACM
   rank: A
   core: https://portal.core.edu.au/conf-ranks/1412
@@ -319,8 +319,8 @@ ISSTA:
   short: null
   full: 18
   format: 1C
-  cfp: '2026-06-25'
-  country: US
+  cfp: '2027-01-11'
+  country: SG
   later: false
 
 MSR:
@@ -333,7 +333,7 @@ MSR:
   short: 4
   full: 10
   format: null
-  cfp: closed
+  cfp: '2026-10-23'
   country: IE
   later: true
 
@@ -361,7 +361,7 @@ POPL:
   short: null
   full: 25
   format: null
-  cfp: '2026-07-09'
+  cfp: closed
   country: MX
   later: false
 
@@ -389,7 +389,7 @@ PPoPP:
   short: null
   full: 10
   format: null
-  cfp: '2026-08-03'
+  cfp: closed
   country: US
   later: false
 
@@ -473,7 +473,7 @@ SEAMS:
   short: 6
   full: 10
   format: null
-  cfp: closed
+  cfp: '2026-10-21'
   country: IE
   later: true
 
@@ -501,7 +501,7 @@ SPLASH:
   short: null
   full: null
   format: null
-  cfp: '2026-06-26'
+  cfp: closed
   country: US
   later: false
 


### PR DESCRIPTION
## Summary

`cfp.yml` had a number of entries whose `cfp` date was either already in the past or marked `closed` with no follow-up. I visited each conference's official website (or searched for its next announced edition) to find the real, currently-open call-for-papers deadline.

Updates applied:

| Conference | Change |
| --- | --- |
| ECOOP'27 | `closed` → `2026-11-19` (Turin, Italy — country `BE` → `IT`) |
| ICPC'27 | `closed` → `2026-11-05` (Dublin, Ireland — country `CA` → `IE`) |
| ICST'27 | `closed` → `2026-11-02` |
| ISSTA | rolled from the passed 2026 edition to the **2027** edition (Singapore), `url`/`year` updated, `cfp` → `2027-01-11` (country `US` → `SG`) |
| MSR'27 | `closed` → `2026-10-23` |
| SEAMS'27 | `closed` → `2026-10-21` |
| APLAS, ICFEM, ICSE, POPL, PPoPP, SPLASH | expired literal dates normalized to `closed` — no new CFP has been announced yet for these |

All other `closed` entries (ASE, CC, CLEI, EASE, ECSA, ICFP, ICFP-SPLASH, ICSME, ISSRE, PLDI, PPDP, QRS, SCAM, SEAA, SLE, SSBSE) were individually checked against their official sites and web search; none has an announced future submission deadline yet, so they are left unchanged.

## Test plan

- [x] `python3 -m yamllint -c .yamllint.yml cfp.yml` — no issues
- [x] `pytest -m 'not content'` — 12 passed
- [x] `pytest -m 'content' --cov-fail-under=0` — 35 passed (includes live link checks for every non-`later` `url`/`core`, confirming the updated ISSTA URL resolves)

---
_Generated by [Claude Code](https://claude.ai/code/session_0175krR6Fj4jPtDpeC3L2T2f)_